### PR TITLE
Support patcher.object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,6 +223,26 @@ If you're happy with the default constructed mock object for a patch (``MagicMoc
 
         logger = patcher('coffee.logger')
 
+
+``exam.decorators.patcher.object``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``patcher.object`` decorator provides the same features as the ``patcher`` decorator, but works with patching attributes of objects (similar to mock's ``mock.patch.object``).  For example, here is how you would use patcher to patch the ``objects`` property of the ``User`` class:
+
+.. code:: python
+
+    from exam.decorators import patcher
+    from exam.cases import Exam
+
+    from myapp import User
+
+    class MyTest(Exam, TestCase):
+
+        manager = patcher.object(User, 'objects')
+
+As with the vanilla ``patcher``, in your test case, ``self.manager`` will be the mock object that ``User.objects`` was patched with.
+
+
 ``exam.helpers``
 ~~~~~~~~~~~~~~~~
 

--- a/exam/decorators.py
+++ b/exam/decorators.py
@@ -62,6 +62,7 @@ class patcher(object):
         self.args = args
         self.kwargs = kwargs
         self.func = None
+        self.patch_func = patch
 
     def __call__(self, func):
         self.func = func
@@ -71,4 +72,10 @@ class patcher(object):
         if self.func:
             self.kwargs['new'] = self.func(instance)
 
-        return patch(*self.args, **self.kwargs)
+        return self.patch_func(*self.args, **self.kwargs)
+
+    @classmethod
+    def object(cls, *args, **kwargs):
+        instance = cls(*args, **kwargs)
+        instance.patch_func = patch.object
+        return instance

--- a/tests/dummy.py
+++ b/tests/dummy.py
@@ -7,6 +7,15 @@ def get_thing():
     global thing
     return thing
 
+
 def get_it():
     global it
     return it
+
+
+def get_prop():
+    return ThingClass.prop
+
+
+class ThingClass(object):
+    prop = True

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -6,7 +6,7 @@ from exam.cases import Exam
 
 from describe import expect
 
-from dummy import get_thing, get_it
+from dummy import get_thing, get_it, get_prop, ThingClass
 
 
 class SimpleTestCase(object):
@@ -117,6 +117,17 @@ class SubclassedCaseWithPatcher(CaseWithPatcher):
     pass
 
 
+class CaseWithPatcherObject(BaseTestCase):
+
+    @patcher.object(ThingClass, 'prop')
+    def dummy_thing(self):
+        return 15
+
+
+class SubclassedCaseWithPatcherObject(CaseWithPatcherObject):
+    pass
+
+
 # TODO: Make the subclass checking just be a subclass of the test case
 class TestExam(Exam, TestCase):
 
@@ -208,3 +219,23 @@ class TestExam(Exam, TestCase):
 
         case.cleanups[0]()
         expect(get_thing()).to != 12
+
+    def test_patcher_object_patches_object(self):
+        case = CaseWithPatcherObject()
+        expect(get_prop()).to != 15
+
+        case.run()
+        expect(get_prop()).to == 15
+
+        [cleanup() for cleanup in case.cleanups]
+        expect(get_prop()).to != 15
+
+    def test_patcher_object_works_with_subclasses(self):
+        case = SubclassedCaseWithPatcherObject()
+
+        expect(get_prop()).to != 15
+        case.run()
+        expect(get_prop()).to == 15
+
+        [cleanup() for cleanup in case.cleanups]
+        expect(get_prop()).to != 15


### PR DESCRIPTION
Adds a `patcher.object` decorator to use a `patcher`, but when you have to patch an object property.

/cc @tkaemming 
