### PR TITLE
Allows @before to decorate a test method and accept a func to call before that method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,18 @@ As you can see even though the parent class defines a ``reset_database``, becaus
 
 In the above example, the ``confirm_user`` method is run immediatly before the ``test_confirmed_users_have_no_token`` method, but **not** the ``test_user_display_name_exists`` method.  The ``@before`` globally decorated ``create_user`` method still runs before each test method.
 
+``@before`` can also be constructed with multiple functions to call before running the test method:
+
+.. code:: python
+
+    class MyTest(Exam, TestCase):
+
+        @before(func1, func2)
+        def test_does_things(self):
+            does_things()
+
+In the above example, ``func1`` and ``func2`` are called in order before ``test_does_things`` is run.
+
 ``exam.decorators.after``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/exam/decorators.py
+++ b/exam/decorators.py
@@ -39,21 +39,14 @@ class fixture(object):
 
 class base(object):
 
-    def __init__(self, thing):
-        self.init_callable = thing
+    def __init__(self, *things):
+        self.init_callables = things
 
     def __call__(self, instance):
-        return self.init_callable(instance)
+        return self.init_callables[0](instance)
 
 
 class before(base):
-
-    def __build_run_before_proxy(self, decorated_func):
-        def inner(testcase):
-            self.init_callable(testcase)
-            decorated_func(testcase)
-
-        return inner
 
     def __call__(self, thing):
         # There a couple possible situations at this point:
@@ -62,7 +55,7 @@ class before(base):
         # ``init_callable`` is the function we want to decorate.  As such,
         # simply call that callable with the instance.
         if isinstance(thing, exam.cases.Exam):
-            return self.init_callable(thing)
+            return self.init_callables[0](thing)
         # If ``thing is not an instance of the test case, it means thi before
         # hook was constructed with a callable that we need to run before
         # actually running the decorated function.  It also means that ``thing``
@@ -72,7 +65,7 @@ class before(base):
         # decorating.
         else:
             def inner(testcase):
-                self.init_callable(testcase)
+                [f(testcase) for f in self.init_callables]
                 thing(testcase)
 
             return inner

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -70,8 +70,15 @@ class CaseWithDecoratedBeforeHook(BaseTestCase):
     def setup_some_state(self):
         self.state = True
 
+    def setup_some_other_state(self):
+        self.other_state = True
+
     @before(setup_some_state)
     def should_have_run_before(self):
+        pass
+
+    @before(setup_some_state, setup_some_other_state)
+    def should_have_run_both_states(self):
         pass
 
 
@@ -145,6 +152,14 @@ class TestExam(Exam, TestCase):
         expect(hasattr(case, 'state')).to == False
         case.should_have_run_before()
         expect(case.state).to == True
+
+    def test_before_decorator_runs_multiple_funcs(self):
+        case = CaseWithDecoratedBeforeHook()
+        expect(hasattr(case, 'state')).to == False
+        expect(hasattr(case, 'other_state')).to == False
+        case.should_have_run_both_states()
+        expect(case.state).to == True
+        expect(case.other_state).to == True
 
     def test_after_adds_each_method_after_test_case(self):
         case = CaseWithAfterHook()


### PR DESCRIPTION
This lets you do stuff like this:

``` python

class TestCase(TestCase):

    def do_stuff(self):
        print 'do stuff'

    @before(do_stuff)
    def test_it_does_things(self):
        print 'it did things'
```

When `test_it_does_things` is run, it will run `do_stuff` first before running `test_it_does_things`. Thus the output would be:

```
do stuff
it did things
```
