### PR TITLE
Fix for Python3

### DIFF
--- a/exam/cases.py
+++ b/exam/cases.py
@@ -34,7 +34,7 @@ class Exam(AssertsMixin):
 
     def __attrs_of_type(self, kind):
         for base in reversed(inspect.getmro(type(self))):
-            for attr, class_value in vars(base).iteritems():
+            for attr, class_value in vars(base).items():
                 resolved_value = getattr(type(self), attr, False)
 
                 if type(resolved_value) is not kind:


### PR DESCRIPTION
Small fix for Python3.
Using items instead of iteritems is slightly less effective in Python 2 but works for Python 3 and avoids an external dependency (on the six module).
