### PR TITLE
Exclude tests directory from source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-exclude tests/ *
+recursive-exclude tests *


### PR DESCRIPTION
This can cause problems when `tests` is an expected module name in other contexts and it resolves to this version instead.

This can be verified with `python setup.py sdist --verbose --dry-run`.
