### PR TITLE
Adding a sequential version of exam.helpers.effect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,7 +348,8 @@ the testing method (like a normal ``@patch``) decorator:
 
 Helper class that is itself callable, whose return values when called are configured via the tuples passed in to the constructor. Useful to build ``side_effect`` callables for Mock objects. Raises TypeError if called with arguments that it was not configured with:
 
-    >>> from exam.objects import call, effect
+    >>> from exam.mock import call
+    >>> from exam.helpers effect
     >>> side_effect = effect((call(1), 'with 1'), (call(2), 'with 2'))
     >>> side_effect(1)
     'with 1'
@@ -363,6 +364,14 @@ If you would like to customize this behavior, subclass `effect` and redefine you
 
     class myeffect(effect):
         call_class = my_call_class
+
+``effect`` also allows you to build sequential callables:
+
+    >>> side_effect = effect((call(1), ['with 1', 'with2']))
+    >>> side_effect(1)
+    'with 1'
+    >>> side_effect(1)
+    'with 2'
 
 ``exam.mock``
 ~~~~~~~~~~~~~

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+import itertools
+
 from tests import TestCase
 from mock import patch, Mock, sentinel
 
@@ -104,12 +106,12 @@ class TestEffect(TestCase):
             (call(1, b=2), 4),
             (call(c=3), 5)
         ]
-        side_effecet = effect(*config)
+        side_effect = effect(*config)
 
-        self.assertEqual(side_effecet(1), 2)
-        self.assertEqual(side_effecet('a'), 3)
-        self.assertEqual(side_effecet(1, b=2), 4)
-        self.assertEqual(side_effecet(c=3), 5)
+        self.assertEqual(side_effect(1), 2)
+        self.assertEqual(side_effect('a'), 3)
+        self.assertEqual(side_effect(1, b=2), 4)
+        self.assertEqual(side_effect(c=3), 5)
 
     def test_raises_type_error_when_called_with_unknown_args(self):
         side_effect = effect((call(1), 5))
@@ -118,3 +120,138 @@ class TestEffect(TestCase):
     def test_can_be_used_with_mutable_data_structs(self):
         side_effect = effect((call([1, 2, 3]), 'list'))
         self.assertEqual(side_effect([1, 2, 3]), 'list')
+        
+    def test_can_be_used_to_return_class(self):
+        class Some(object):
+            pass
+        side_effect = effect((call(1), Some))
+        self.assertEqual(side_effect(1), Some)
+        self.assertEqual(side_effect(1), Some)#always returns Some
+    
+    def test_can_be_used_to_return_instance(self):
+        class Some(object):
+            pass
+        side_effect = effect((call(1), Some()))
+        self.assertEqual(side_effect(1).__class__, Some().__class__)
+        self.assertEqual(side_effect(1).__class__, Some().__class__)#always returns a Some instance
+    
+    def test_can_be_used_to_return_mock_instance(self):
+        side_effect = effect((call(1), Mock()))
+        self.assertEqual(side_effect(1).__class__.__name__, Mock().__class__.__name__)
+        self.assertEqual(side_effect(1).__class__.__name__, Mock().__class__.__name__)#always returns a Mock instance
+    
+    def test_can_be_used_with_various_iterators(self):
+        side_effect = effect((call(1), itertools.repeat(10, 3)))
+        for i in range(3):
+            self.assertEqual(side_effect(1), 10)
+        with self.assertRaises(TypeError):
+            side_effect(1)
+        #trying another iterator    
+        side_effect = effect((call(1), itertools.chain([1,1,1], [2,2,2])))
+        for i in range(3):
+            self.assertEqual(side_effect(1), 1)
+        for i in range(3):
+            self.assertEqual(side_effect(1), 2)
+        with self.assertRaises(TypeError):
+            side_effect(1)
+    
+    def test_sequential_config_with_generator(self):
+        def ten_times():
+            for i in range(9):
+                yield i
+        config = (
+            (call('can be called ten times'), ten_times()),#note generator must be called
+        )
+        side_effect = effect(*config)
+        for i in range(9):
+            self.assertEqual(side_effect('can be called ten times'), i)
+        with self.assertRaises(TypeError):
+            side_effect('can be called ten times')
+        
+    def test_sequential_config_with_multiple_elements_each_called_only_once(self):
+        config = (
+            (call('with 1, again and then TypeError'), ['with 1', 'with 1 again']), 
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect('with 1, again and then TypeError'), 'with 1')
+        self.assertEqual(side_effect('with 1, again and then TypeError'), 'with 1 again')
+        with self.assertRaises(TypeError):
+            side_effect('with 1, again and then TypeError')
+    
+    def test_sequential_config_with_one_element_called_only_once(self):
+        config = (
+            (call('with 2, followed by TypeError'), ['with 2']), 
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect('with 2, followed by TypeError'), 'with 2')
+        with self.assertRaises(TypeError):
+            side_effect('with 2, followed by TypeError')
+    
+    def test_empty_sequential_config_raises_exception_on_first_call(self):
+        config = (
+            (call('Empty iterable, raises TypeError on first call'), []), 
+        )
+        side_effect = effect(*config)
+        with self.assertRaises(TypeError):
+            side_effect('Empty iterable, raises TypeError on first call')
+            
+    def test_using_cycle_config_can_be_called_infinitely(self):
+        config = (
+            (call('Can be called forever'), itertools.cycle(['with 1', 'with 1 again'])), 
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect('Can be called forever'), 'with 1')
+        self.assertEqual(side_effect('Can be called forever'), 'with 1 again')
+        self.assertEqual(side_effect('Can be called forever'), 'with 1')
+        self.assertEqual(side_effect('Can be called forever'), 'with 1 again')
+    
+    def test_dicts_should_be_returned_as_is(self):
+        config = (
+            (call('A dict should always be returned as is'), {'this': 'is a dict'}), 
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect('A dict should always be returned as is'), {'this': 'is a dict'})
+        self.assertEqual(side_effect('A dict should always be returned as is'), {'this': 'is a dict'})
+        
+    def test_you_can_put_data_structures_into_sequential_configs(self):
+        config = (
+            (call('returns a dict and then TypeError'), [{'this': 'is a dict in a list'}]), 
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect('returns a dict and then TypeError'), {'this': 'is a dict in a list'})
+        with self.assertRaises(TypeError):
+            side_effect('returns a dict and then TypeError')
+    
+    def test_you_can_put_data_structures_into_infinite_sequential_configs(self):
+        config = (
+            (call('Always a dict'), itertools.cycle([{'this': 'is a dict in a list'}])), 
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect('Always a dict'), {'this': 'is a dict in a list'})
+        self.assertEqual(side_effect('Always a dict'), {'this': 'is a dict in a list'})
+    
+    def test_sequential_callable_with_a_bunch_of_configs(self):
+        config = (
+            (call(1), itertools.cycle(['with 1', 'with 1 again'])), 
+            (call(2), 'with 2'), 
+            (call(3), ['with 3',]),
+            (call(4), []),
+            (call(5), [{'this': 'is a dict in a list'}]),
+            (call(6), {'this': 'is a dict'})
+        )
+        side_effect = effect(*config)
+        self.assertEqual(side_effect(1), 'with 1')
+        self.assertEqual(side_effect(2), 'with 2')
+        self.assertEqual(side_effect(3), 'with 3')
+        self.assertEqual(side_effect(1), 'with 1 again')
+        self.assertEqual(side_effect(1), 'with 1')
+        self.assertEqual(side_effect(2), 'with 2')#second call
+        with self.assertRaises(TypeError):
+            side_effect(3)
+        with self.assertRaises(TypeError):
+            side_effect(4)
+        self.assertEqual(side_effect(5), {'this': 'is a dict in a list'})
+        with self.assertRaises(TypeError):
+            side_effect(5)
+        self.assertEqual(side_effect(6), {'this': 'is a dict'})
+        


### PR DESCRIPTION
@Fluxx
Hi Jeff, I found a use case for a version of `exam.helpers.effect` which could be used to test sequential calls of a Mock, each with equal call signatures but different return value. 

Perhaps this could be of use to other users of your excellent library :smile: 

Also updated the docs and fixed a couple of small typos I came across. 

Please let me know what you think!
