### PR TITLE
Remove nose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,7 @@ except ImportError:
 
 install_requires = ['mock']
 lint_requires = ['pep8', 'pyflakes']
-tests_require = ['']
-
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
-else:
-    tests_require.append('unittest')
+tests_require = ['unittest']
 
 setup_requires = []
 

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ except ImportError:
 
 install_requires = ['mock']
 lint_requires = ['pep8', 'pyflakes']
-tests_require = ['nose']
+tests_require = ['']
 
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')
+else:
+    tests_require.append('unittest')
 
 setup_requires = []
-if 'nosetests' in sys.argv[1:]:
-    setup_requires.append('nose')
 
 setup(
     name='exam',


### PR DESCRIPTION
As nose won't work with Python 3.9/3.10

Using `python{3,2} -m unittest{,2} discover -s tests/ -v` worked fine